### PR TITLE
WIP: Compile blerpcproto library from JCenter()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,8 @@ licenses:
   - google-gdk-license-.+
 before_install:
   - linters/install-linters.sh
-  - mkdir blerpc/libs
 script:
   - gradle blerpcproto:assemble
-  - cp blerpcproto/build/libs/blerpcproto.jar blerpc/libs/blerpcproto.jar
   - gradle assembleRelease --stacktrace --no-daemon
   - gradle testReleaseUnitTest --info
   - linters/run-linters.sh

--- a/blerpc/build.gradle
+++ b/blerpc/build.gradle
@@ -34,7 +34,7 @@ configurations.all {
 
 dependencies {
     compile group: 'findbugs', name: 'annotations', version: '1.0.0'
-    compile files('libs/blerpcproto.jar')
+    compile "com.github.monnoroch:blerpcproto-android:0.0.2"
     compile 'com.google.guava:guava:20.0'
     compile 'com.google.protobuf:protobuf-java:3.2.0'
     compile 'com.google.protobuf:protoc:3.0.0'
@@ -54,7 +54,7 @@ publish {
     groupId = 'com.github.monnoroch'
     repoName = 'blerpc-android'
     artifactId = 'blerpc-android'
-    publishVersion = '0.0.6'
+    publishVersion = '0.0.7'
     desc = 'A library for simplifying working with blutooth low energy devices.'
     licences = ['MIT']
     website = 'https://github.com/monnoroch/blerpc-android'


### PR DESCRIPTION
Compile blerpcproto library from JCenter() for avoiding dependency conflicts if application, like duplicating files error when proguard is enabled.

Related to #9.