### PR TITLE
Cleanups and refactorings.

### DIFF
--- a/blerpc/src/main/java/com/blerpc/BleRpcChannel.java
+++ b/blerpc/src/main/java/com/blerpc/BleRpcChannel.java
@@ -165,7 +165,6 @@ public class BleRpcChannel implements RpcChannel {
     }
 
     private void handleError(String format, Object ... args) {
-        logger.info(String.format(format, args));
         RpcCall currentCall = finishRpcCall();
         notifyCallFailed(currentCall, format, args);
         startNextCall();
@@ -180,9 +179,6 @@ public class BleRpcChannel implements RpcChannel {
         } else if (Arrays.equals(value, DISABLE_NOTIFICATION_VALUE)) {
             SubscriptionCallsGroup subscription = getUnsubscribingSubscription(characteristicUuid);
             subscription.status = SubscriptionStatus.UNSUBSCRIBED;
-            // New rpc calls might have been added while unsubscription.
-            // If this is the case, start a new subscription. If there are not any, just clean up, which is exactly
-            // what startNextCall will do.
         } else {
             checkArgument(false, "Unexpected value \"%s\" of the subscription state.", Arrays.toString(value));
         }
@@ -215,8 +211,8 @@ public class BleRpcChannel implements RpcChannel {
         }
 
         SubscriptionStatus subscriptionStatus = getSubscription(characteristicUuid).status;
-        if (subscriptionStatus == ConnectionStatus.UNSUBSCRIBING
-            || subscriptionStatus == ConnectionStatus.SUBSCRIBING) {
+        if (subscriptionStatus == SubscriptionStatus.UNSUBSCRIBING
+            || subscriptionStatus == SubscriptionStatus.SUBSCRIBING) {
             return;
         }
 

--- a/blerpc/src/main/java/com/blerpc/BleRpcChannel.java
+++ b/blerpc/src/main/java/com/blerpc/BleRpcChannel.java
@@ -215,7 +215,8 @@ public class BleRpcChannel implements RpcChannel {
         }
 
         SubscriptionStatus subscriptionStatus = getSubscription(characteristicUuid).status;
-        if (subscriptionStatus == UNSUBSCRIBING || subscriptionStatus == SUBSCRIBING) {
+        if (subscriptionStatus == ConnectionStatus.UNSUBSCRIBING
+            || subscriptionStatus == ConnectionStatus.SUBSCRIBING) {
             return;
         }
 
@@ -565,9 +566,6 @@ public class BleRpcChannel implements RpcChannel {
     }
 
     private final BluetoothGattCallback gattCallback = new BluetoothGattCallback() {
-        // TODO(andrew): Check the parameters that will be passed after turning off Bluetooth or disconnecting the
-        // remote device. Currently, we assume that for these actions this callback will be called with the DISCONNECTED
-        // status.
         @Override
         public void onConnectionStateChange(BluetoothGatt gatt, int status, int state) {
             workHandler.post(() -> {

--- a/blerpc/src/main/java/com/blerpc/BleRpcChannel.java
+++ b/blerpc/src/main/java/com/blerpc/BleRpcChannel.java
@@ -481,13 +481,13 @@ public class BleRpcChannel implements RpcChannel {
     private boolean startNextSubscribeCall(BluetoothGatt bluetoothGatt, RpcCall rpcCall) {
         SubscriptionCallsGroup subscription = getSubscription(rpcCall.getCharacteristic());
         callInProgress = true;
-        subscription.status != SubscriptionStatus.SUBSCRIBING;
+        subscription.status = SubscriptionStatus.SUBSCRIBING;
         try {
             makeSubscribeRequest(bluetoothGatt, rpcCall);
             return true;
         } catch (MakeRequestException exception) {
             calls.poll();
-            subscription.status != SubscriptionStatus.UNSUBSCRIBED;
+            subscription.status = SubscriptionStatus.UNSUBSCRIBED;
             callInProgress = false;
             failAllSubscribersAndClear(subscription, exception.getMessage());
             return false;

--- a/blerpc/src/main/java/com/blerpc/BleRpcChannel.java
+++ b/blerpc/src/main/java/com/blerpc/BleRpcChannel.java
@@ -210,13 +210,11 @@ public class BleRpcChannel implements RpcChannel {
             return;
         }
 
-        SubscriptionStatus subscriptionStatus = getSubscription(characteristicUuid).status;
-        if (subscriptionStatus == SubscriptionStatus.UNSUBSCRIBING
-            || subscriptionStatus == SubscriptionStatus.SUBSCRIBING) {
+        SubscriptionCallsGroup subscription = getSubscription(characteristicUuid);
+        if (subscription.status != SubscriptionStatus.SUBSCRIBED) {
             return;
         }
 
-        SubscriptionCallsGroup subscription = getSubscribedSubscription(characteristicUuid);
         BluetoothGattDescriptor descriptor = getDescriptor(characteristic, subscription.descriptorUuid);
         // If all calls were cancelled, abandon the subscription.
         subscription.clearCanceled();
@@ -239,12 +237,6 @@ public class BleRpcChannel implements RpcChannel {
     private SubscriptionCallsGroup getSubscribingSubscription(UUID characteristicUuid) {
         SubscriptionCallsGroup subscription = getSubscriptionWithSubscribers(characteristicUuid);
         checkArgument(subscription.status == SubscriptionStatus.SUBSCRIBING, "The characteristic %s is not subscribing.", characteristicUuid);
-        return subscription;
-    }
-
-    private SubscriptionCallsGroup getSubscribedSubscription(UUID characteristicUuid) {
-        SubscriptionCallsGroup subscription = getSubscriptionWithSubscribers(characteristicUuid);
-        checkArgument(subscription.status == SubscriptionStatus.SUBSCRIBED, "The characteristic %s is not subscribed.", characteristicUuid);
         return subscription;
     }
 


### PR DESCRIPTION
- Add @VisibleForTesting annotations appropriately.
- Clean up the code a bit.
- Use enums instead of sets of booleans.
- MethodDescriptor in a SubscribtionCallsGroup ot remove weird getAnySubscriber method.
- Remove unnecessary logs on errors that get sent to the callback.

This PR doesn't change any user-visible logic so no test changes here.