### PR TITLE
Don't throw an error, when device response is bigger that expected.

### DIFF
--- a/blerpc/src/main/java/com/blerpc/AnnotationMessageConverter.java
+++ b/blerpc/src/main/java/com/blerpc/AnnotationMessageConverter.java
@@ -162,8 +162,8 @@ public class AnnotationMessageConverter implements MessageConverter {
     }
     checkHasExtension(message);
     int messageBytesSize = getMessageExtension(message).getSizeBytes();
-    checkArgument(value.length == messageBytesSize,
-        "Declared size %s of message %s is not equal to device response size %s",
+    checkArgument(value.length >= messageBytesSize,
+        "Declared size %s of message %s is bigger, than device response size %s",
         messageBytesSize,
         message.getDescriptorForType().getName(),
         value.length);

--- a/blerpc/src/test/java/com/blerpc/AnnotationMessageConverterTest.java
+++ b/blerpc/src/test/java/com/blerpc/AnnotationMessageConverterTest.java
@@ -52,6 +52,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class AnnotationMessageConverterTest {
 
   private static final byte[] TEST_INT_BYTE_ARRAY = new byte[]{15, 1, -122, -96};
+  private static final byte[] TEST_INT_BYTE_ARRAY_EXTRA_BYTE = new byte[]{15, 1, -122, -96, 50};
   private static final byte[] TEST_LONG_BYTE_ARRAY = new byte[]{2, 6, 8, 2, 84, 11, -28, 0};
   private static final byte[] TEST_BOOL_BYTE_ARRAY = new byte[]{1};
   private static final byte[] TEST_BYTE_STRING_BYTE_ARRAY = new byte[]{1, 2, 3, 4, 5, 6, 7, 8};
@@ -447,6 +448,11 @@ public class AnnotationMessageConverterTest {
 
   @Test
   public void deserializeResponse_responseByteSizeBiggerThatExpected() throws Exception {
+    assertThat(converter.deserializeResponse(null, TestIntegerMessage.getDefaultInstance(),
+        TEST_INT_BYTE_ARRAY_EXTRA_BYTE))
+        .isEqualTo(TestIntegerMessage.newBuilder()
+            .setIntValue(intFrom(TEST_INT_BYTE_ARRAY))
+            .build());
     converter.deserializeResponse(null, TestIntegerMessage.getDefaultInstance(), new byte[10]);
   }
 

--- a/blerpc/src/test/java/com/blerpc/AnnotationMessageConverterTest.java
+++ b/blerpc/src/test/java/com/blerpc/AnnotationMessageConverterTest.java
@@ -453,7 +453,6 @@ public class AnnotationMessageConverterTest {
         .isEqualTo(TestIntegerMessage.newBuilder()
             .setIntValue(intFrom(TEST_INT_BYTE_ARRAY))
             .build());
-    converter.deserializeResponse(null, TestIntegerMessage.getDefaultInstance(), new byte[10]);
   }
 
   @Test

--- a/blerpc/src/test/java/com/blerpc/AnnotationMessageConverterTest.java
+++ b/blerpc/src/test/java/com/blerpc/AnnotationMessageConverterTest.java
@@ -440,9 +440,14 @@ public class AnnotationMessageConverterTest {
   }
 
   @Test
-  public void deserializeResponse_wrongMessageByteSize() throws Exception {
-    assertError(() -> converter.deserializeResponse(null, TestIntegerMessage.getDefaultInstance(), new byte[10]),
-        "Declared size 4 of message TestIntegerMessage is not equal to device response size 10");
+  public void deserializeResponse_responseByteSizeLessThatExpected() throws Exception {
+    assertError(() -> converter.deserializeResponse(null, TestIntegerMessage.getDefaultInstance(), new byte[3]),
+        "Declared size 4 of message TestIntegerMessage is bigger, than device response size 3");
+  }
+
+  @Test
+  public void deserializeResponse_responseByteSizeBiggerThatExpected() throws Exception {
+    converter.deserializeResponse(null, TestIntegerMessage.getDefaultInstance(), new byte[10]);
   }
 
   @Test

--- a/blerpc/src/test/java/com/blerpc/TestServiceTest.java
+++ b/blerpc/src/test/java/com/blerpc/TestServiceTest.java
@@ -220,7 +220,7 @@ public class TestServiceTest {
   public void testRead_invalidDeviceResponse() throws Exception {
     when(characteristic.getValue()).thenReturn(TEST_READ_INVALID_RESPONSE_BYTES);
     testService.testReadChar(controller, TEST_READ_REQUEST, callbackRead);
-    assertError(this::connectAndRun, "Declared size 4 of message TestBleReadResponse is not equal to device response size 3");
+    assertError(this::connectAndRun, "Declared size 4 of message TestBleReadResponse is bigger, than device response size 3");
   }
 
   @Test


### PR DESCRIPTION
Fixed #59.