### PR TITLE
Handle case, when connectGatt() returns null.

### DIFF
--- a/blerpc/src/main/java/com/blerpc/BleRpcChannel.java
+++ b/blerpc/src/main/java/com/blerpc/BleRpcChannel.java
@@ -150,7 +150,10 @@ public class BleRpcChannel implements RpcChannel {
 
   private void startConnection() {
     connectionStatus = ConnectionStatus.CONNECTING;
-    bluetoothGatt = Optional.of(bluetoothDevice.connectGatt(context, true, gattCallback));
+    bluetoothGatt = Optional.fromNullable(bluetoothDevice.connectGatt(context, true, gattCallback));
+    if (!bluetoothGatt.isPresent()) {
+      failAllAndReset("Could not get bluetooth gatt.");
+    }
   }
 
   private void handleResult(byte[] value) {

--- a/blerpc/src/test/java/com/blerpc/BleRpcChannelTest.java
+++ b/blerpc/src/test/java/com/blerpc/BleRpcChannelTest.java
@@ -286,6 +286,15 @@ public class BleRpcChannelTest {
   }
 
   @Test
+  public void testFailAllAndResetWhenConnectGattError() throws Exception {
+    when(bluetoothDevice.connectGatt(eq(context), anyBoolean(), bluetoothCallback.capture()))
+        .thenReturn(null);
+    callMethod(controller);
+    assertCallFailed(controller);
+    onConnectionStateChange(0, BluetoothProfile.STATE_DISCONNECTED);
+  }
+
+  @Test
   public void testDoNotConnectAndFailWhenDisconnectedState() throws Exception {
     callMethod(controller);
     onConnectionStateChange(0, BluetoothProfile.STATE_DISCONNECTED);


### PR DESCRIPTION
Fixed #57.