### PR TITLE
Use library-specific app_name

### DIFF
--- a/blerpc/src/main/res/values/strings.xml
+++ b/blerpc/src/main/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-  <string name="app_name">BleRpc</string>
+  <string name="blerpc_app_name">BleRpc</string>
 </resources>

--- a/reactive-blerpc-test/src/main/res/values/strings.xml
+++ b/reactive-blerpc-test/src/main/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">reactive-blerpc-test</string>
+    <string name="blerpc_test_app_name">reactive-blerpc-test</string>
 </resources>


### PR DESCRIPTION
in a best practice for android libraries
is to avoid names conflicting with default application name resource.