### PR TITLE
Disable autoconnect

### DIFF
--- a/blerpc/src/main/java/com/blerpc/BleRpcChannel.java
+++ b/blerpc/src/main/java/com/blerpc/BleRpcChannel.java
@@ -150,7 +150,7 @@ public class BleRpcChannel implements RpcChannel {
 
   private void startConnection() {
     connectionStatus = ConnectionStatus.CONNECTING;
-    bluetoothGatt = Optional.fromNullable(bluetoothDevice.connectGatt(context, true, gattCallback));
+    bluetoothGatt = Optional.fromNullable(bluetoothDevice.connectGatt(context, /*autoConnect=*/ false, gattCallback));
     if (!bluetoothGatt.isPresent()) {
       failAllAndReset("Could not get bluetooth gatt.");
     }


### PR DESCRIPTION
proved unstable on most devices, waits indefinitely to connect and is generally slower.