### PR TITLE
Disable characteristic notification on framework part too

### DIFF
--- a/blerpc/src/main/java/com/blerpc/BleRpcChannel.java
+++ b/blerpc/src/main/java/com/blerpc/BleRpcChannel.java
@@ -173,7 +173,7 @@ public class BleRpcChannel implements RpcChannel {
     startNextCall();
   }
 
-  private void handleSubscribe(BluetoothGattCharacteristic characteristic, byte[] value) {
+  private void handleSubscribe(BluetoothGatt gatt, BluetoothGattCharacteristic characteristic, byte[] value) {
     RpcCall rpcCall = finishRpcCall();
     UUID characteristicUuid = characteristic.getUuid();
     if (Arrays.equals(value, ENABLE_NOTIFICATION_VALUE)) {
@@ -644,7 +644,7 @@ public class BleRpcChannel implements RpcChannel {
           handleSubscribeError(characteristic, descriptor.getUuid(), descriptor.getValue(),
               "Failed to subscribe to descriptor %s: status=%d.", descriptor.getUuid(), status);
         } else {
-          handleSubscribe(characteristic, descriptor.getValue());
+          handleSubscribe(gatt, characteristic, descriptor.getValue());
         }
       });
     }

--- a/blerpc/src/main/java/com/blerpc/BleRpcChannel.java
+++ b/blerpc/src/main/java/com/blerpc/BleRpcChannel.java
@@ -186,6 +186,11 @@ public class BleRpcChannel implements RpcChannel {
       // New rpc calls might have been added since we started unsubscribing.
       subscription.clearCanceled();
       if (!subscription.hasAnySubscriber()) {
+        failIfFalse(
+            gatt.setCharacteristicNotification(characteristic, /*enable=*/ false),
+            "Failed to disable notification for characteristic %s in service %s.",
+            rpcCall.characteristicUuid,
+            rpcCall.serviceUuid);
         subscriptions.remove(subscription.characteristicUuid);
         return;
       }

--- a/blerpc/src/test/java/com/blerpc/BleRpcChannelTest.java
+++ b/blerpc/src/test/java/com/blerpc/BleRpcChannelTest.java
@@ -1,5 +1,6 @@
 package com.blerpc;
 
+import static com.blerpc.Assert.assertError;
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -198,6 +199,7 @@ public class BleRpcChannelTest {
     when(bluetoothGatt.writeCharacteristic(characteristic2)).thenReturn(true);
     when(bluetoothGatt.setCharacteristicNotification(characteristic, true)).thenReturn(true);
     when(bluetoothGatt.setCharacteristicNotification(characteristic2, true)).thenReturn(true);
+    when(bluetoothGatt.setCharacteristicNotification(characteristic, false)).thenReturn(true);
     when(bluetoothGatt.writeDescriptor(descriptor)).thenReturn(true);
     when(bluetoothGatt.writeDescriptor(descriptor2)).thenReturn(true);
     when(gattService.getCharacteristic(TEST_CHARACTERISTIC)).thenReturn(characteristic);
@@ -774,8 +776,21 @@ public class BleRpcChannelTest {
     finishSubscribing(descriptor);
 
     localController.startCancel();
+    onCharacteristicChanged(characteristic);
     onUnsubscribe(descriptor);
     verify(bluetoothGatt).setCharacteristicNotification(descriptor.getCharacteristic(), false);
+  }
+
+  @Test
+  public void testUnsubscribe_disableNotificationFail() throws Exception {
+    BleRpcController localController = spy(controller);
+    callSubscribeMethod(localController, callback);
+    finishSubscribing(descriptor);
+
+    localController.startCancel();
+    onCharacteristicChanged(characteristic);
+    when(bluetoothGatt.setCharacteristicNotification(descriptor.getCharacteristic(), false)).thenReturn(false);
+    assertError(() -> onUnsubscribe(descriptor), "Failed to disable notification");
   }
 
   @Test

--- a/blerpc/src/test/java/com/blerpc/BleRpcChannelTest.java
+++ b/blerpc/src/test/java/com/blerpc/BleRpcChannelTest.java
@@ -768,6 +768,17 @@ public class BleRpcChannelTest {
   }
 
   @Test
+  public void testUnsubscribe() throws Exception {
+    BleRpcController localController = spy(controller);
+    callSubscribeMethod(localController, callback);
+    finishSubscribing(descriptor);
+
+    localController.startCancel();
+    onUnsubscribe(descriptor);
+    verify(bluetoothGatt).setCharacteristicNotification(descriptor.getCharacteristic(), false);
+  }
+
+  @Test
   public void testValueChangedBeforeOnDescriptorWriteSubscribe() {
     callSubscribeMethod(controller, callback);
     finishConnecting();


### PR DESCRIPTION
it is not enough to just write disable notification
descriptor, should also disable notifications on framework.

Related to #83