### PR TITLE
Fixed a bug with possibility for starting two RPCs in parallel.

### DIFF
--- a/blerpc/src/main/java/com/blerpc/BleRpcChannel.java
+++ b/blerpc/src/main/java/com/blerpc/BleRpcChannel.java
@@ -301,13 +301,13 @@ public class BleRpcChannel implements RpcChannel {
     } catch (CouldNotConvertMessageException exception) {
       notifyCallFailed(currentCall, exception.getMessage());
     }
-    startNextCall();
+    startNextCallIfNotInProgress();
   }
 
   private void handleError(String format, Object... args) {
     RpcCall currentCall = finishRpcCall();
     notifyCallFailed(currentCall, format, args);
-    startNextCall();
+    startNextCallIfNotInProgress();
   }
 
   private boolean startNextSubscribeCall(BluetoothGatt bluetoothGatt, RpcCall rpcCall) {
@@ -350,7 +350,7 @@ public class BleRpcChannel implements RpcChannel {
     SubscriptionCallsGroup subscription = getSubscribingSubscription(rpcCall.getCharacteristic());
     subscription.status = SubscriptionStatus.SUBSCRIBED;
     rpcCall.controller.onSubscribeSuccess();
-    startNextCall();
+    startNextCallIfNotInProgress();
   }
 
   private void handleSubscribedError(int status) {
@@ -360,7 +360,7 @@ public class BleRpcChannel implements RpcChannel {
     failAllSubscribersAndClear(subscription,
         "Failed to subscribe to descriptor %s in characteristic %s in service %s with status %d.",
         rpcCall.getDescriptor(), characteristicUuid, rpcCall.getService(), status);
-    startNextCall();
+    startNextCallIfNotInProgress();
   }
 
   private void startUnsubscribing(SubscriptionCallsGroup subscription) {

--- a/blerpc/src/main/proto/test_ble_service.proto
+++ b/blerpc/src/main/proto/test_ble_service.proto
@@ -195,6 +195,13 @@ service TestBleService {
         };
   }
 
+  rpc TestReadChar2 (TestBleReadRequest) returns (TestBleReadResponse) {
+    option (com.blerpc.characteristic) = {
+            uuid: "F0CDBA74-0451-4000-B000-000000000000"
+            type: READ
+        };
+  }
+
   rpc TestWriteChar2 (TestBleReadRequest) returns (TestBleReadResponse) {
     option (com.blerpc.characteristic) = {
             uuid: "F0CDBA74-0451-4000-B000-000000000000"


### PR DESCRIPTION
`notifyResultForCall`, `callOnSubscribeSuccess` and others call user code. It's called through a `Handler`, so it's supposed to be async, but the implementation is not guaranteed and it's possible that the callback is executed immediately. If that happens, that callback can trigger the next RPC call in the queue to start, which means calling `startNextCall()` is incorrect any more. This PR fixes it by always calling `startNextCallIfNotInProgress()` instead.