### PR TITLE
Revert "Disable characteristic notification on framework part too"

### DIFF
--- a/blerpc/src/main/java/com/blerpc/BleRpcChannel.java
+++ b/blerpc/src/main/java/com/blerpc/BleRpcChannel.java
@@ -175,7 +175,7 @@ public class BleRpcChannel implements RpcChannel {
     startNextCall();
   }
 
-  private void handleSubscribe(BluetoothGatt gatt, BluetoothGattCharacteristic characteristic, byte[] value) {
+  private void handleSubscribe(BluetoothGattCharacteristic characteristic, byte[] value) {
     RpcCall rpcCall = finishRpcCall();
     UUID characteristicUuid = characteristic.getUuid();
     if (Arrays.equals(value, ENABLE_NOTIFICATION_VALUE)) {
@@ -188,11 +188,6 @@ public class BleRpcChannel implements RpcChannel {
       // New rpc calls might have been added since we started unsubscribing.
       subscription.clearCanceled();
       if (!subscription.hasAnySubscriber()) {
-        failIfFalse(
-            gatt.setCharacteristicNotification(characteristic, /*enable=*/ false),
-            "Failed to disable notification for characteristic %s in service %s.",
-            rpcCall.characteristicUuid,
-            rpcCall.serviceUuid);
         subscriptions.remove(subscription.characteristicUuid);
         return;
       }
@@ -649,7 +644,7 @@ public class BleRpcChannel implements RpcChannel {
           handleSubscribeError(characteristic, descriptor.getUuid(), descriptor.getValue(),
               "Failed to subscribe to descriptor %s: status=%d.", descriptor.getUuid(), status);
         } else {
-          handleSubscribe(gatt, characteristic, descriptor.getValue());
+          handleSubscribe(characteristic, descriptor.getValue());
         }
       });
     }

--- a/blerpc/src/test/java/com/blerpc/BleRpcChannelTest.java
+++ b/blerpc/src/test/java/com/blerpc/BleRpcChannelTest.java
@@ -1,5 +1,6 @@
 package com.blerpc;
 
+import static com.blerpc.Assert.assertError;
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;

--- a/blerpc/src/test/java/com/blerpc/BleRpcChannelTest.java
+++ b/blerpc/src/test/java/com/blerpc/BleRpcChannelTest.java
@@ -1,6 +1,5 @@
 package com.blerpc;
 
-import static com.blerpc.Assert.assertError;
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -236,7 +235,6 @@ public class BleRpcChannelTest {
     when(bluetoothGatt.writeCharacteristic(characteristic2)).thenReturn(true);
     when(bluetoothGatt.setCharacteristicNotification(characteristic, true)).thenReturn(true);
     when(bluetoothGatt.setCharacteristicNotification(characteristic2, true)).thenReturn(true);
-    when(bluetoothGatt.setCharacteristicNotification(characteristic, false)).thenReturn(true);
     when(bluetoothGatt.writeDescriptor(descriptor)).thenReturn(true);
     when(bluetoothGatt.writeDescriptor(descriptor2)).thenReturn(true);
     when(gattService.getCharacteristic(TEST_CHARACTERISTIC)).thenReturn(characteristic);
@@ -810,30 +808,6 @@ public class BleRpcChannelTest {
     verify(callback).run(TEST_SUBSCRIBE_RESPONSE);
     assertCallSucceeded(controller2);
     verify(callback2).run(TEST_SUBSCRIBE_RESPONSE2);
-  }
-
-  @Test
-  public void testUnsubscribe() throws Exception {
-    BleRpcController localController = spy(controller);
-    callSubscribeMethod(localController, callback);
-    finishSubscribing(descriptor);
-
-    localController.startCancel();
-    onCharacteristicChanged(characteristic);
-    onUnsubscribe(descriptor);
-    verify(bluetoothGatt).setCharacteristicNotification(descriptor.getCharacteristic(), false);
-  }
-
-  @Test
-  public void testUnsubscribe_disableNotificationFail() throws Exception {
-    BleRpcController localController = spy(controller);
-    callSubscribeMethod(localController, callback);
-    finishSubscribing(descriptor);
-
-    localController.startCancel();
-    onCharacteristicChanged(characteristic);
-    when(bluetoothGatt.setCharacteristicNotification(descriptor.getCharacteristic(), false)).thenReturn(false);
-    assertError(() -> onUnsubscribe(descriptor), "Failed to disable notification");
   }
 
   @Test


### PR DESCRIPTION
Reverts Monnoroch/blerpc-android#84

The PR was incorrect as `failIfFalse` should not be used in that context.