### PR TITLE
Fix message size lesser than expected crash

### DIFF
--- a/blerpc/src/main/java/com/blerpc/AnnotationMessageConverter.java
+++ b/blerpc/src/main/java/com/blerpc/AnnotationMessageConverter.java
@@ -60,7 +60,6 @@ public class AnnotationMessageConverter implements MessageConverter {
     return requestBytes;
   }
 
-  @SuppressWarnings("OptionalGetWithoutIsPresent") // absent value is impossible here
   private void serializeMessage(byte[] requestBytes,
                                 Message message,
                                 FieldExtension messageFieldExtension,
@@ -70,33 +69,35 @@ public class AnnotationMessageConverter implements MessageConverter {
       FieldDescriptor fieldDescriptor = entry.getKey();
       Object fieldValue = entry.getValue();
       String fieldName = fieldDescriptor.getName();
-      Optional<FieldExtension> relativeBytesRangeFieldExtension =
+      @SuppressWarnings("OptionalGetWithoutIsPresent") // absent value is impossible here
+      FieldExtension relativeBytesRangeFieldExtension =
           getRelativeBytesRangeFieldExtension(
-              messageFieldExtension,
-              Optional.absent(),
-              fieldDescriptor,
-              message,
-              useFieldByteOrder);
+                  messageFieldExtension,
+                  Optional.absent(),
+                  fieldDescriptor,
+                  message,
+                  useFieldByteOrder)
+              .get();
 
       JavaType fieldType = fieldDescriptor.getType().getJavaType();
       switch (fieldType) {
         case MESSAGE:
-          serializeMessage(requestBytes, (Message) fieldValue, relativeBytesRangeFieldExtension.get(), hasByteOrder(fieldDescriptor));
+          serializeMessage(requestBytes, (Message) fieldValue, relativeBytesRangeFieldExtension, hasByteOrder(fieldDescriptor));
           break;
         case INT:
-          serializeInt(requestBytes, (Integer) fieldValue, relativeBytesRangeFieldExtension.get(), fieldName);
+          serializeInt(requestBytes, (Integer) fieldValue, relativeBytesRangeFieldExtension, fieldName);
           break;
         case LONG:
-          serializeLong(requestBytes, (Long) fieldValue, relativeBytesRangeFieldExtension.get(), fieldName);
+          serializeLong(requestBytes, (Long) fieldValue, relativeBytesRangeFieldExtension, fieldName);
           break;
         case ENUM:
-          serializeEnum(requestBytes, (EnumValueDescriptor) fieldValue, relativeBytesRangeFieldExtension.get(), fieldName);
+          serializeEnum(requestBytes, (EnumValueDescriptor) fieldValue, relativeBytesRangeFieldExtension, fieldName);
           break;
         case BOOLEAN:
-          serializeBoolean(requestBytes, (Boolean) fieldValue, relativeBytesRangeFieldExtension.get(), fieldName);
+          serializeBoolean(requestBytes, (Boolean) fieldValue, relativeBytesRangeFieldExtension, fieldName);
           break;
         case BYTE_STRING:
-          serializeByteString(requestBytes, (ByteString) fieldValue, relativeBytesRangeFieldExtension.get(), fieldName);
+          serializeByteString(requestBytes, (ByteString) fieldValue, relativeBytesRangeFieldExtension, fieldName);
           break;
         // TODO(#5): Add support of String, Float and Double.
         default:

--- a/blerpc/src/main/proto/test_messages_with_byte_options.proto
+++ b/blerpc/src/main/proto/test_messages_with_byte_options.proto
@@ -393,3 +393,35 @@ enum TestBigValueEnum {
   UNKNOWN_ENUM_VALUE = 0;
   ENUM_VALUE_1 = 222222222;
 }
+
+message TestExcessivePrimitiveAtTheEndMessage {
+  option (com.blerpc.message) = {
+        size_bytes: 12
+    };
+
+  int32 int_value = 1 [(com.blerpc.field) = {
+        from_byte: 0
+        to_byte: 4
+    }];
+
+  int64 long_value = 2 [(com.blerpc.field) = {
+        from_byte: 4
+        to_byte: 12
+    }];
+}
+
+message TestExcessiveMessageAtTheEndMessage {
+  option (com.blerpc.message) = {
+        size_bytes: 12
+    };
+
+  int32 int_value = 1 [(com.blerpc.field) = {
+        from_byte: 0
+        to_byte: 4
+    }];
+
+  TestLongMessage embedded_message = 2 [(com.blerpc.field) = {
+        from_byte: 4
+        to_byte: 12
+    }];
+}

--- a/blerpc/src/test/java/com/blerpc/AnnotationMessageConverterTest.java
+++ b/blerpc/src/test/java/com/blerpc/AnnotationMessageConverterTest.java
@@ -441,9 +441,23 @@ public class AnnotationMessageConverterTest {
   }
 
   @Test
-  public void deserializeResponse_responseByteSizeLessThatExpected() throws Exception {
-    assertError(() -> converter.deserializeResponse(null, TestIntegerMessage.getDefaultInstance(), new byte[3]),
-        "Declared size 4 of message TestIntegerMessage is bigger, than device response size 3");
+  public void deserializeResponse_responseByteSizeLessThatExpected_primitiveAtTheEnd() throws Exception {
+    assertThat(converterLittleEndian.deserializeResponse(null, TestOverrideMessageOrderMessage.getDefaultInstance(),
+        TEST_INT_BYTE_ARRAY))
+        .isEqualTo(TestOverrideMessageOrderMessage.newBuilder()
+            .setIntValue(littleEndianIntFrom(TEST_INT_BYTE_ARRAY))
+            .build());
+  }
+
+
+  @Test
+  public void deserializeResponse_responseByteSizeLessThatExpected_messageAtTheEnd() throws Exception {
+    assertThat(converterLittleEndian.deserializeResponse(null, TestNonPrimitiveFieldMessage.getDefaultInstance(),
+        TEST_INT_BYTE_ARRAY))
+        .isEqualTo(TestNonPrimitiveFieldMessage.newBuilder()
+            .setIntValue(littleEndianIntFrom(TEST_INT_BYTE_ARRAY))
+            .setEmbeddedMessage(TestLongMessage.getDefaultInstance())
+            .build());
   }
 
   @Test

--- a/blerpc/src/test/java/com/blerpc/AnnotationMessageConverterTest.java
+++ b/blerpc/src/test/java/com/blerpc/AnnotationMessageConverterTest.java
@@ -11,6 +11,8 @@ import com.blerpc.device.test.proto.TestDoubleValueMessage;
 import com.blerpc.device.test.proto.TestEmptyMessage;
 import com.blerpc.device.test.proto.TestEnum;
 import com.blerpc.device.test.proto.TestEnumMessage;
+import com.blerpc.device.test.proto.TestExcessiveMessageAtTheEndMessage;
+import com.blerpc.device.test.proto.TestExcessivePrimitiveAtTheEndMessage;
 import com.blerpc.device.test.proto.TestFloatValueMessage;
 import com.blerpc.device.test.proto.TestIntegerMessage;
 import com.blerpc.device.test.proto.TestLongMessage;
@@ -442,20 +444,20 @@ public class AnnotationMessageConverterTest {
 
   @Test
   public void deserializeResponse_responseByteSizeLessThatExpected_primitiveAtTheEnd() throws Exception {
-    assertThat(converterLittleEndian.deserializeResponse(null, TestOverrideMessageOrderMessage.getDefaultInstance(),
+    assertThat(converter.deserializeResponse(null, TestExcessivePrimitiveAtTheEndMessage.getDefaultInstance(),
         TEST_INT_BYTE_ARRAY))
-        .isEqualTo(TestOverrideMessageOrderMessage.newBuilder()
-            .setIntValue(littleEndianIntFrom(TEST_INT_BYTE_ARRAY))
+        .isEqualTo(TestExcessivePrimitiveAtTheEndMessage.newBuilder()
+            .setIntValue(intFrom(TEST_INT_BYTE_ARRAY))
             .build());
   }
 
 
   @Test
   public void deserializeResponse_responseByteSizeLessThatExpected_messageAtTheEnd() throws Exception {
-    assertThat(converterLittleEndian.deserializeResponse(null, TestNonPrimitiveFieldMessage.getDefaultInstance(),
+    assertThat(converter.deserializeResponse(null, TestExcessiveMessageAtTheEndMessage.getDefaultInstance(),
         TEST_INT_BYTE_ARRAY))
-        .isEqualTo(TestNonPrimitiveFieldMessage.newBuilder()
-            .setIntValue(littleEndianIntFrom(TEST_INT_BYTE_ARRAY))
+        .isEqualTo(TestExcessiveMessageAtTheEndMessage.newBuilder()
+            .setIntValue(intFrom(TEST_INT_BYTE_ARRAY))
             .build());
   }
 

--- a/blerpc/src/test/java/com/blerpc/AnnotationMessageConverterTest.java
+++ b/blerpc/src/test/java/com/blerpc/AnnotationMessageConverterTest.java
@@ -456,7 +456,6 @@ public class AnnotationMessageConverterTest {
         TEST_INT_BYTE_ARRAY))
         .isEqualTo(TestNonPrimitiveFieldMessage.newBuilder()
             .setIntValue(littleEndianIntFrom(TEST_INT_BYTE_ARRAY))
-            .setEmbeddedMessage(TestLongMessage.getDefaultInstance())
             .build());
   }
 

--- a/blerpc/src/test/java/com/blerpc/TestServiceTest.java
+++ b/blerpc/src/test/java/com/blerpc/TestServiceTest.java
@@ -215,13 +215,6 @@ public class TestServiceTest {
   }
 
   @Test
-  public void testRead_invalidDeviceResponse() throws Exception {
-    when(characteristic.getValue()).thenReturn(TEST_READ_INVALID_RESPONSE_BYTES);
-    testService.testReadChar(controller, TEST_READ_REQUEST, callbackRead);
-    assertError(this::connectAndRun, "Declared size 4 of message TestBleReadResponse is bigger, than device response size 3");
-  }
-
-  @Test
   public void testWrite() throws Exception {
     when(characteristic.getValue()).thenReturn(TEST_WRITE_RESPONSE_BYTES);
     testService.testWriteChar(controller, TEST_WRITE_REQUEST, callbackWrite);

--- a/blerpc/src/test/java/com/blerpc/TestServiceTest.java
+++ b/blerpc/src/test/java/com/blerpc/TestServiceTest.java
@@ -1,6 +1,5 @@
 package com.blerpc;
 
-import static com.blerpc.Assert.assertError;
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;


### PR DESCRIPTION
Parser is now backward-compatible too: received messages which have
lesser fields than expected in the proto declaration (aka messages from
legacy firmwares) now have new fields initialized with default values.

Related to: #103